### PR TITLE
removed unused requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-pyOpenSSL==17.0.0
 requests==2.14.2


### PR DESCRIPTION
It looks like we're not using pyOpenSSL at all.
Not imported, not a dependency of other requirements (only requests at the time of this PR)

Tested with no pyOpenSSL, with pyOpenSSL v17.0.0 (the broken one), v 17.5.0 (the fixed one) and v18.0.0 (latest one).
In all 4 cases all banks worked but https://openapi.bankofireland.com/open-banking/v2.2/unsecured-sme-loans (which fails on curl as well and can be reached from chrome but not firefox).